### PR TITLE
Configure a json based serializer instead of binary.

### DIFF
--- a/OrientDB.yaml
+++ b/OrientDB.yaml
@@ -6,3 +6,4 @@ name: OrientDB
 password: rootpwd
 port: 8182
 username: root
+serializer: { className: org.apache.tinkerpop.gremlin. driver.ser.GraphSONMessageSerializerV1d0, config: { serializeResultToString: true }}


### PR DESCRIPTION
The default serializer for OrientDB is binary.
Edges and vertices can only be deserialized with OrientDB libs.

``serializer: { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0, config: { ioRegistries: [**org.apache.tinkerpop.gremlin.orientdb.io.OrientIoRegistry**] }}``

With this change, the client requests a json based serialization that doesn't rely on OrientDB specific jars. It's less efficient but more portable.